### PR TITLE
upgrade to node 12.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb; \
     dpkg -i --force-depends erlang-solutions_1.0_all.deb;
 
 # setup nodejs apt repo
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 
 # install nodejs and erlang
 RUN apt-get update && apt-get install -yq \


### PR DESCRIPTION
We are standardizing on node 12.x on various projects. This PR makes that change to our release builder.